### PR TITLE
Remove default, add placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ echo $locale->getText('world'); // prints "World"
 
 // Use placeholders
 echo $locale->getText('likes', [ 'likesAmount' => 12, 'commentsAmount' => 55 ]); // prints "You have 12 likes and 55 comments."
-echo $locale->getText('likes'); // prints "You have {likesAmount} likes and {commentsAmount} comments.". If you don't provide placeholder value, we don't touch it
+echo $locale->getText('likes'); // prints "You have {likesAmount} likes and {commentsAmount} comments.". If you don't provide placeholder value, the string is returned unchanged.
 
 // Get translation of different language
 $locale->setDefault('he-IL');

--- a/README.md
+++ b/README.md
@@ -24,13 +24,28 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 use Utopia\Locale\Locale;
 
 // Init translations
-Locale::setLanguageFromArray('en-US', ['hello' => 'Hello','world' => 'World']); // Set English
+Locale::setLanguageFromArray('en-US', [
+    'hello' => 'Hello',
+    'world' => 'World',
+    'likes' => 'You have {likesAmount} likes and {commentsAmount} comments.'
+]); // Set English
 Locale::setLanguageFromArray('he-IL', ['hello' => 'שלום',]); // Set Hebrew
 Locale::setLanguageFromJSON('hi-IN', 'path/to/translations.json'); // Set Hindi
 
+// Create locale instance
+$locale = new Locale('en-US'); // en-US will be set as default language
+
 // Get translation
-echo Locale::getText('hello'); // prints "שלום"
+echo Locale::getText('hello'); // prints "Hello"
 echo Locale::getText('world'); // prints "World"
+
+// Use placeholders
+echo Locale::getText('likes', [ 'likesAmount' => 12, 'commentsAmount' => 55 ]); // prints "You have 12 likes and 55 comments."
+echo Locale::getText('likes'); // prints "You have {likesAmount} likes and {commentsAmount} comments.". If you don't provide placeholder value, we don't touch it
+
+// Get translation of different language
+$locale->setDefault('he-IL');
+echo Locale::getText('hello'); // prints "שלום"
 ```
 
 ## Expected Structure of Translations
@@ -61,6 +76,20 @@ When using `setLanguageFromJSON($code, $path)` for the `en-US` locale you need t
 ## System Requirements
 
 Utopia Framework requires PHP 7.4 or later. We recommend using the latest PHP version whenever possible.
+
+## Tests
+
+To run the tests, first you need to install libraries:
+```shell
+docker run --rm --interactive --tty \
+  --volume $PWD:/app \
+  composer update --ignore-platform-reqs --optimize-autoloader --no-plugins --no-scripts --prefer-dist
+```
+
+Finally, you can run the tests:
+```shell
+docker run --rm -v $(pwd):$(pwd):rw -w $(pwd) php:7.4-cli-alpine sh -c "vendor/bin/phpunit tests/Locale/LocaleTest.php"
+```
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ Locale::setLanguageFromJSON('hi-IN', 'path/to/translations.json'); // Set Hindi
 $locale = new Locale('en-US'); // en-US will be set as default language
 
 // Get translation
-echo Locale::getText('hello'); // prints "Hello"
-echo Locale::getText('world'); // prints "World"
+echo $locale->getText('hello'); // prints "Hello"
+echo $locale->getText('world'); // prints "World"
 
 // Use placeholders
-echo Locale::getText('likes', [ 'likesAmount' => 12, 'commentsAmount' => 55 ]); // prints "You have 12 likes and 55 comments."
-echo Locale::getText('likes'); // prints "You have {likesAmount} likes and {commentsAmount} comments.". If you don't provide placeholder value, we don't touch it
+echo $locale->getText('likes', [ 'likesAmount' => 12, 'commentsAmount' => 55 ]); // prints "You have 12 likes and 55 comments."
+echo $locale->getText('likes'); // prints "You have {likesAmount} likes and {commentsAmount} comments.". If you don't provide placeholder value, we don't touch it
 
 // Get translation of different language
 $locale->setDefault('he-IL');
-echo Locale::getText('hello'); // prints "שלום"
+echo $locale->getText('hello'); // prints "שלום"
 ```
 
 ## Expected Structure of Translations

--- a/src/Locale/Locale.php
+++ b/src/Locale/Locale.php
@@ -87,9 +87,9 @@ class Locale
      * @return mixed
      * @throws Exception
      */
-    public function getText(string $key, $default = null)
+    public function getText(string $key, $placeholders = [])
     {
-        $default = (\is_null($default)) ? '{{' . $key . '}}' : $default;
+        $default = '{{' . $key . '}}';
 
         if (!\array_key_exists($key, self::$language[$this->default])) {
             if (self::$exceptions) {
@@ -99,6 +99,12 @@ class Locale
             return $default;
         }
 
-        return self::$language[$this->default][$key];
+        $translation = self::$language[$this->default][$key];
+
+        foreach ($placeholders as $placeholderKey => $placeholderValue) {
+            $translation = str_replace('{' . $placeholderKey . '}', $placeholderValue, $translation);
+        }
+
+        return $translation;
     }
 }

--- a/tests/Locale/LocaleTest.php
+++ b/tests/Locale/LocaleTest.php
@@ -75,10 +75,11 @@ class LocaleTest extends TestCase
         ]));
 
         // Test exceptions
+        $locale->setDefault('he-IL');
         Locale::$exceptions = true;
 
         try {
-            $locale->getText('world', 'empty');
+            $locale->getText('world');
         } catch (\Throwable $exception) {
             $this->assertInstanceOf(Exception::class, $exception);
             return;

--- a/tests/Locale/LocaleTest.php
+++ b/tests/Locale/LocaleTest.php
@@ -28,8 +28,8 @@ class LocaleTest extends TestCase
     {
         Locale::$exceptions = false; // Disable exceptions
 
-        Locale::setLanguageFromArray('en-US', ['hello' => 'Hello','world' => 'World']); // Set English
-        Locale::setLanguageFromArray('he-IL', ['hello' => 'שלום',]); // Set Hebrew
+        Locale::setLanguageFromArray('en-US', ['hello' => 'Hello','world' => 'World', 'helloPlaceholder' => 'Hello {name} {surname}!', 'numericPlaceholder' => 'We have {usersAmount} users registered.', 'multiplePlaceholders' => 'Lets repeat: {word}, {word}, {word}']); // Set English
+        Locale::setLanguageFromArray('he-IL', ['hello' => 'שלום']); // Set Hebrew
         Locale::setLanguageFromJSON('hi-IN', realpath(__DIR__.'/../hi-IN.json')); // Set Hindi
     }
 
@@ -52,9 +52,30 @@ class LocaleTest extends TestCase
         $locale->setDefault('he-IL');
 
         $this->assertEquals('שלום', $locale->getText('hello'));
-        $this->assertEquals('empty', $locale->getText('world', 'empty'));
+        // $this->assertEquals('empty', $locale->getText('world', 'empty')); Has been removed in 0.5.0
 
-        Locale::$exceptions = true; // Enable exceptions
+        // Test placeholders
+        $locale->setDefault('en-US');
+
+        $this->assertEquals('Hello Matej Bačo!', $locale->getText("helloPlaceholder", [
+            'name' => 'Matej',
+            'surname' => 'Bačo'
+        ]));
+        $this->assertEquals('Hello Matej {surname}!', $locale->getText("helloPlaceholder", [
+            'name' => 'Matej',
+        ]));
+        $this->assertEquals('Hello {name} {surname}!', $locale->getText("helloPlaceholder"));
+
+        $this->assertEquals('We have 12 users registered.', $locale->getText("numericPlaceholder", [
+            'usersAmount' => 6 + 6,
+        ]));
+
+        $this->assertEquals('Lets repeat: Appwrite, Appwrite, Appwrite', $locale->getText("multiplePlaceholders", [
+            'word' => 'Appwrite',
+        ]));
+
+        // Test exceptions
+        Locale::$exceptions = true;
 
         try {
             $locale->getText('world', 'empty');


### PR DESCRIPTION
## Release note

⚠️ This release includes **breaking changes**! ⚠️

- We removed second parameter `$default`. To achieve the same logic, you can do this in your code:

```php
$translation = $locale->getText('myMissingTranslation');

if($translation == '{{myMissingTranslation}}') {
  $translation = 'Translation not found!';
}

echo $translation;
```

If you have exceptions enabled, you could:

```php
Locale::$exceptions = true;

try {
    $translation = $locale->getText('myMissingTranslation');
    echo $translation;
} catch (\Throwable $exception) {
    echo "Translation not found!";
}
```

- We added new second parameter `$placeholders`. Please refer to [README.md](https://github.com/utopia-php/locale/blob/master/README.md) to learn how to use it.