### PR TITLE
Feat: getText default

### DIFF
--- a/src/Locale/Locale.php
+++ b/src/Locale/Locale.php
@@ -123,17 +123,17 @@ class Locale
      *
      * @param  string  $key
      * @param  array<string, string|int>  $placeholders
-     * @param  string|null $default
+     * @param  string|null  $default
      * @return mixed
      *
      * @throws Exception
      */
-    public function getText(string $key, array $placeholders = [], string|null $default = self::DEFAULT_DYNAMIC_KEY)
+    public function getText(string $key, string|null $default = self::DEFAULT_DYNAMIC_KEY, array $placeholders = [])
     {
         $defaultExists = \array_key_exists($key, self::$language[$this->default]);
         $fallbackExists = \array_key_exists($key, self::$language[$this->fallback ?? ''] ?? []);
 
-        $translation = $default === self::DEFAULT_DYNAMIC_KEY ? '{{' . $key . '}}' : $default;
+        $translation = $default === self::DEFAULT_DYNAMIC_KEY ? '{{'.$key.'}}' : $default;
 
         if ($fallbackExists) {
             $translation = self::$language[$this->fallback ?? ''][$key];
@@ -145,6 +145,10 @@ class Locale
 
         if (! $defaultExists && ! $fallbackExists && self::$exceptions) {
             throw new Exception('Key named "'.$key.'" not found');
+        }
+
+        if (\is_null($translation)) {
+            return null;
         }
 
         foreach ($placeholders as $placeholderKey => $placeholderValue) {

--- a/src/Locale/Locale.php
+++ b/src/Locale/Locale.php
@@ -6,6 +6,8 @@ use Exception;
 
 class Locale
 {
+    const string DEFAULT_DYNAMIC_KEY = '[[defaultDynamciKey]]'; // Replaced at runime by $key wrapped in {{ and }}
+
     /**
      * @var array<string, array<string, string>>
      */
@@ -121,16 +123,17 @@ class Locale
      *
      * @param  string  $key
      * @param  array<string, string|int>  $placeholders
+     * @param  string|null $default
      * @return mixed
      *
      * @throws Exception
      */
-    public function getText(string $key, array $placeholders = [])
+    public function getText(string $key, array $placeholders = [], string|null $default = self::DEFAULT_DYNAMIC_KEY)
     {
         $defaultExists = \array_key_exists($key, self::$language[$this->default]);
         $fallbackExists = \array_key_exists($key, self::$language[$this->fallback ?? ''] ?? []);
 
-        $translation = '{{'.$key.'}}';
+        $translation = $default === self::DEFAULT_DYNAMIC_KEY ? '{{' . $key . '}}' : $default;
 
         if ($fallbackExists) {
             $translation = self::$language[$this->fallback ?? ''][$key];

--- a/src/Locale/Locale.php
+++ b/src/Locale/Locale.php
@@ -6,7 +6,7 @@ use Exception;
 
 class Locale
 {
-    const string DEFAULT_DYNAMIC_KEY = '[[defaultDynamciKey]]'; // Replaced at runime by $key wrapped in {{ and }}
+    const string DEFAULT_DYNAMIC_KEY = '[[defaultDynamicKey]]'; // Replaced at runime by $key wrapped in {{ and }}
 
     /**
      * @var array<string, array<string, string>>

--- a/tests/Locale/LocaleTest.php
+++ b/tests/Locale/LocaleTest.php
@@ -65,20 +65,20 @@ class LocaleTest extends TestCase
         // Test placeholders
         $locale->setDefault('en-US');
 
-        $this->assertEquals('Hello Matej Bačo!', $locale->getText('helloPlaceholder', [
+        $this->assertEquals('Hello Matej Bačo!', $locale->getText('helloPlaceholder', placeholders: [
             'name' => 'Matej',
             'surname' => 'Bačo',
         ]));
-        $this->assertEquals('Hello Matej {{surname}}!', $locale->getText('helloPlaceholder', [
+        $this->assertEquals('Hello Matej {{surname}}!', $locale->getText('helloPlaceholder', placeholders: [
             'name' => 'Matej',
         ]));
         $this->assertEquals('Hello {{name}} {{surname}}!', $locale->getText('helloPlaceholder'));
 
-        $this->assertEquals('We have 12 users registered.', $locale->getText('numericPlaceholder', [
+        $this->assertEquals('We have 12 users registered.', $locale->getText('numericPlaceholder', placeholders: [
             'usersAmount' => 6 + 6,
         ]));
 
-        $this->assertEquals('Lets repeat: Appwrite, Appwrite, Appwrite', $locale->getText('multiplePlaceholders', [
+        $this->assertEquals('Lets repeat: Appwrite, Appwrite, Appwrite', $locale->getText('multiplePlaceholders', placeholders: [
             'word' => 'Appwrite',
         ]));
 
@@ -119,5 +119,16 @@ class LocaleTest extends TestCase
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
         }
+    }
+
+    public function testGetTextDefault(): void
+    {
+        $locale = new Locale('en-US');
+
+        $this->assertEquals('Hello', $locale->getText('hello'));
+        $this->assertEquals('{{missing}}', $locale->getText('missing'));
+        $this->assertEquals('A custom text', $locale->getText('missing', default: 'A custom text'));
+        $this->assertEquals(null, $locale->getText('missing', default: null));
+        $this->assertEquals('Sorry Matej, missing text', $locale->getText('missing', placeholders: ['name' => 'Matej'], default: 'Sorry {{name}}, missing text'));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept a custom default for missing translations, applied with placeholders for dynamic fallback messages.
  * Option to return no text (null) for missing translations to intentionally omit UI content.
  * When no default is provided, a clear placeholder using the missing key is shown to highlight gaps.

* **Tests**
  * Added tests verifying default behaviors, null-return, and placeholder interpolation in defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->